### PR TITLE
Feature/feature flag toggle

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -14,6 +14,8 @@
     "elite-types": "^1.0.0"
   },
   "dependencies": {
+    "@material-ui/core": "^4.9.3",
+    "@material-ui/icons": "^4.9.1",
     "react": "^16.12.0"
   }
 }

--- a/packages/components/src/general/featureFlag.component.tsx
+++ b/packages/components/src/general/featureFlag.component.tsx
@@ -1,7 +1,12 @@
-import React, { PureComponent, createContext, Context } from 'react';
-import { FeatureMap } from 'elite-types';
+import React, { PureComponent, createContext, ReactNode } from 'react';
+import { FeatureMap, FeatureSetterFunction } from 'elite-types';
 
-const FeatureFlags: Context<FeatureMap> = createContext<FeatureMap>({});
+const FeatureFlags = createContext<{ featureMap: FeatureMap } & { setFeatureEnabled: FeatureSetterFunction }>({
+  featureMap: {},
+  setFeatureEnabled: () => {
+    throw new Error("Unimplemented functionality 'setFeatureEnabled' in FeatureFlagsProvider value");
+  },
+});
 
 export interface FeatureToggleProperties {
   readonly inverted?: boolean;
@@ -14,16 +19,16 @@ export class FeatureFlag extends PureComponent<FeatureToggleProperties> {
 
     return (
       <FeatureFlags.Consumer>
-        {(featureMap: FeatureMap) => {
+        {({ featureMap }) => {
           if ((featureMap[featureName] && !inverted) || (!featureMap[featureName] && inverted)) {
             return children;
-          } else {
-            return null;
           }
+          return null;
         }}
       </FeatureFlags.Consumer>
     );
   }
 }
 
+export const FeatureFlagsConsumer = FeatureFlags.Consumer;
 export const FeatureFlagsProvider = FeatureFlags.Provider;

--- a/packages/components/src/general/featureMenu.component.tsx
+++ b/packages/components/src/general/featureMenu.component.tsx
@@ -1,5 +1,5 @@
 import { FormControlLabel, IconButton, Menu, MenuItem, Switch, Typography } from '@material-ui/core';
-import FeatureMenuIcon from '@material-ui/icons/Build';
+import FeatureMenuIcon from '@material-ui/icons/Toys';
 import * as React from 'react';
 import { FeatureFlagsConsumer } from './featureFlag.component';
 

--- a/packages/components/src/general/featureMenu.component.tsx
+++ b/packages/components/src/general/featureMenu.component.tsx
@@ -1,0 +1,58 @@
+import { FormControlLabel, IconButton, Menu, MenuItem, Switch, Typography } from '@material-ui/core';
+import FeatureMenuIcon from '@material-ui/icons/Build';
+import * as React from 'react';
+import { FeatureFlagsConsumer } from './featureFlag.component';
+
+export interface FeatureMenuProps {}
+
+export const FeatureMenu = (props: FeatureMenuProps) => {
+  const [anchorElement, setAnchorElement] = React.useState<null | HTMLElement>(null);
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorElement(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorElement(null);
+  };
+
+  return (
+    <>
+      <IconButton aria-controls={'feature-menu'} aria-haspopup={'true'} color={'inherit'} onClick={handleClick}>
+        <FeatureMenuIcon />
+      </IconButton>
+      <Menu
+        id={'feature-menu'}
+        anchorEl={anchorElement}
+        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+        keepMounted={true}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        open={Boolean(anchorElement)}
+        onClose={handleClose}
+      >
+        <MenuItem>
+          <Typography variant={'h6'}>Feature Flags</Typography>
+        </MenuItem>
+
+        <FeatureFlagsConsumer>
+          {({ featureMap, setFeatureEnabled }) =>
+            Object.keys(featureMap).map(featureKey => (
+              <MenuItem key={featureKey}>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={featureMap[featureKey]}
+                      onChange={() => setFeatureEnabled(featureKey, !featureMap[featureKey])}
+                      color={'primary'}
+                    />
+                  }
+                  label={featureKey}
+                />
+              </MenuItem>
+            ))
+          }
+        </FeatureFlagsConsumer>
+      </Menu>
+    </>
+  );
+};

--- a/packages/components/src/general/index.ts
+++ b/packages/components/src/general/index.ts
@@ -1,2 +1,2 @@
 export * from './errorBoundary.component';
-export * from './featureFlag.component';
+export { FeatureFlag, FeatureFlagsProvider, FeatureToggleProperties } from './featureFlag.component';

--- a/packages/components/src/general/index.ts
+++ b/packages/components/src/general/index.ts
@@ -1,2 +1,3 @@
 export * from './errorBoundary.component';
 export { FeatureFlag, FeatureFlagsProvider, FeatureToggleProperties } from './featureFlag.component';
+export * from './featureMenu.component';

--- a/packages/components/src/navigation/navigationBar.component.tsx
+++ b/packages/components/src/navigation/navigationBar.component.tsx
@@ -3,6 +3,7 @@ import { AppBar, Toolbar, makeStyles, IconButton, Theme, createStyles, Typograph
 import MenuIcon from '@material-ui/icons/Menu';
 import { RouteDrawer } from './routeDrawer.component';
 import { AppRoute } from 'elite-types';
+import { FeatureMenu } from '../general/featureMenu.component';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -58,6 +59,7 @@ export const NavigationBar = (props: NavigationBarProps) => {
             <Typography className={classes.title} variant={'h6'} noWrap>
               {title}
             </Typography>
+            <FeatureMenu />
             <Button color={'inherit'}>Login</Button>
           </Toolbar>
         </AppBar>

--- a/packages/configuration/src/index.ts
+++ b/packages/configuration/src/index.ts
@@ -2,6 +2,6 @@ import devConfig from './development.configuration';
 import prodConfig from './production.configuration';
 import { Configuration } from 'elite-types';
 
-export function getConfiguration(): Configuration {
-  return process.env.NODE_ENV === 'development' ? devConfig : prodConfig;
+export function getBaseConfiguration(environment = process.env.NODE_ENV): Configuration {
+  return environment === 'development' ? devConfig : prodConfig;
 }

--- a/packages/frontend/src/app.tsx
+++ b/packages/frontend/src/app.tsx
@@ -1,6 +1,6 @@
 import { ErrorBoundaryComponent, FeatureFlagsProvider, NavigationBar } from 'elite-components';
-import { getConfiguration } from 'elite-configuration';
-import { AppPath, Configuration, getDisplayNameForRoute, getLinkForRoute } from 'elite-types';
+import { getBaseConfiguration } from 'elite-configuration';
+import { AppPath, getDisplayNameForRoute, getLinkForRoute, FeatureMap, FeatureSetterFunction } from 'elite-types';
 import * as React from 'react';
 import { hot } from 'react-hot-loader';
 import { Redirect, Route, Switch } from 'react-router';
@@ -8,36 +8,42 @@ import { Router } from 'react-router-dom';
 import history from './util/history';
 import { APP_ROUTES } from './util/routes';
 
-// Global bootstrap: load configuration
-const configuration: Configuration = getConfiguration();
+const AppComponent = () => {
+  const baseConfiguration = getBaseConfiguration();
+  const [featureMap, setFeatureMap] = React.useState(baseConfiguration.featureMap);
+  const featureFlagsValue: { featureMap: FeatureMap; setFeatureEnabled: FeatureSetterFunction } = {
+    featureMap,
+    setFeatureEnabled: (feature: string, enabled: boolean) => setFeatureMap({ ...featureMap, [feature]: enabled }),
+  };
 
-export const AppComponent = () => (
-  <FeatureFlagsProvider value={configuration.featureMap}>
-    <Router history={history}>
-      <ErrorBoundaryComponent>
-        <Switch>
-          {APP_ROUTES.map((route, index) => (
-            <Route
-              key={index}
-              {...route}
-              render={props => (
-                <>
-                  <NavigationBar
-                    routes={APP_ROUTES}
-                    title={getDisplayNameForRoute(route)}
-                    onNavigateTo={r => history.push(getLinkForRoute(r))}
-                  />
-                  {route.render(props)}
-                </>
-              )}
-            />
-          ))}
-          {/* Error 404 Fallback */}
-          <Route path={AppPath.ERROR} render={() => <Redirect to={AppPath.HOME} />} />
-        </Switch>
-      </ErrorBoundaryComponent>
-    </Router>
-  </FeatureFlagsProvider>
-);
+  return (
+    <FeatureFlagsProvider value={featureFlagsValue}>
+      <Router history={history}>
+        <ErrorBoundaryComponent>
+          <Switch>
+            {APP_ROUTES.map((route, index) => (
+              <Route
+                key={index}
+                {...route}
+                render={props => (
+                  <>
+                    <NavigationBar
+                      routes={APP_ROUTES}
+                      title={getDisplayNameForRoute(route)}
+                      onNavigateTo={r => history.push(getLinkForRoute(r))}
+                    />
+                    {route.render(props)}
+                  </>
+                )}
+              />
+            ))}
+            {/* Error 404 Fallback */}
+            <Route path={AppPath.ERROR} render={() => <Redirect to={AppPath.HOME} />} />
+          </Switch>
+        </ErrorBoundaryComponent>
+      </Router>
+    </FeatureFlagsProvider>
+  );
+};
 
 export const App = hot(module)(AppComponent);

--- a/packages/types/src/config/featureSetter.type.ts
+++ b/packages/types/src/config/featureSetter.type.ts
@@ -1,0 +1,1 @@
+export type FeatureSetterFunction = (feature: string, enabled: boolean) => void;

--- a/packages/types/src/config/index.ts
+++ b/packages/types/src/config/index.ts
@@ -1,2 +1,3 @@
 export * from './configuration.type';
 export * from './featureMap.type';
+export * from './featureSetter.type';


### PR DESCRIPTION
Core idea for feature development for elite-se.xyz: push to production fast, but 'hide' potentially unstable features behind feature flag.

This pull request adds an AppBar menu for toggling feature-flags on or of easily at runtime. This allows users to beta test on an opt-in basis or disable features if they're unstable. Additionally, developers may deliver code to and test it on the live elite-se.xyz system faster.